### PR TITLE
issue#23 Tag Archive Pages Show ALL widgets

### DIFF
--- a/includes/widgets/display.php
+++ b/includes/widgets/display.php
@@ -83,7 +83,9 @@ if( !function_exists( 'widgetopts_display_callback' ) ):
                 $visibility['tags'] = array();
             }
 
-            if( isset( $visibility['taxonomies']['post_tag'] ) && $visibility_opts == 'hide' ){
+            if( ( isset( $visibility['taxonomies']['post_tag'] ) && $visibility_opts == 'hide' ) ||
+                ( !isset( $visibility['taxonomies']['post_tag'] ) && $visibility_opts == 'show' )
+            ) {
                 $hidden = true; //hide to all tags
             }elseif( isset( $visibility['taxonomies']['post_tag'] ) && $visibility_opts == 'show' ){
                 $hidden = false; //hide to all tags


### PR DESCRIPTION
Missing line for TAG archives. When widget is set to "Show only" it display on every tag archiver page even if it's not set to display on it.