### PR TITLE
Update display.php

### DIFF
--- a/includes/widgets/display.php
+++ b/includes/widgets/display.php
@@ -355,7 +355,7 @@ if( !function_exists( 'widgetopts_display_callback' ) ):
                     return true;
                 }
                 if ( stristr($display_logic,"return")===false ){
-                    $display_logic="return (" . $display_logic . ");";
+                    $display_logic="return (" . html_entity_decode($display_logic, ENT_COMPAT | ENT_HTML401 | ENT_QUOTES) . ");";
                 }
                 if ( !eval( $display_logic ) ){
                     return false;


### PR DESCRIPTION
Bug when aply php logic in widget visibility #49

Estoy intentando aplicar código PHP para cambiar la visibilidad de un widget, pero cuando introduzco el caracter "<", el plugin no funciona.
He investigado y he visto que en la linea 360 aproximadamente, la función eval no funciona al interpretar este código como un elemento de HTML (la llave de abrir etiquetas).

Te dejo una posible solución a esto.

$display_logic="return (" . html_entity_decode($display_logic, ENT_COMPAT | ENT_HTML401 | ENT_QUOTES) . ");";