### PR TITLE
Account for widget callbacks being array objects

### DIFF
--- a/includes/widgets/extras.php
+++ b/includes/widgets/extras.php
@@ -126,7 +126,7 @@ if( !function_exists( 'widgetopts_sidebars_widgets' ) ){
 					$show = $checked[ $widget ];
 				} else {
 					$opts = $wp_registered_widgets[ $widget ];
-					$id_base = is_array( $opts['callback'] ) ? $opts['callback'][0]->id_base : $opts['callback'];
+					$id_base = is_array( $opts['callback'] ) || $opts['callback'] instanceof ArrayAccess ? $opts['callback'][0]->id_base : $opts['callback'];
 
 					if ( ! $id_base ) {
 						continue;

--- a/includes/widgets/extras.php
+++ b/includes/widgets/extras.php
@@ -128,7 +128,7 @@ if( !function_exists( 'widgetopts_sidebars_widgets' ) ){
 					$opts = $wp_registered_widgets[ $widget ];
 					$id_base = is_array( $opts['callback'] ) || $opts['callback'] instanceof ArrayAccess ? $opts['callback'][0]->id_base : $opts['callback'];
 
-					if ( ! $id_base ) {
+					if ( ! is_string( $id_base ) ) {
 						continue;
 					}
 


### PR DESCRIPTION
Fixes #64.

See also support forum topic: https://wordpress.org/support/topic/php-recoverable-fatal-error-when-switching-amp-mode/

This implements a fix I proposed in another support topic: https://wordpress.org/support/topic/standard-template-mode-internal-error/#post-12547053

This fixes compatibility with the AMP plugin which wraps all the registered widget callbacks with an object that implements `ArrayAccess`.