### PR TITLE
Fix: PHP Warning:  preg_match(): Unknown modifier '/'

### DIFF
--- a/includes/extras.php
+++ b/includes/extras.php
@@ -505,8 +505,8 @@ function widgetopts_safe_eval($expression)
         '/\bdrop\b/i',
         '/\balter\b/i',
         '/\btruncate\b/i',
-        '/\bgrant\b/i/',
-        '/\brevoke\b/i/',
+        '/\bgrant\b/i',
+        '/\brevoke\b/i',
 
         // WordPress-specific database functions
         '/\bwp_insert_post\b/i',


### PR DESCRIPTION
The trailing / after the i modifier is unnecessary and results in PHP treating it as a part of the regex, leading to the "Unknown modifier" error.

`PHP message: PHP Warning:  preg_match(): Unknown modifier '/' in /var/www/wordpress/wp-content/plugins/widget-options/includes/extras.php on line 599; PHP message: PHP Warning:  preg_match(): Unknown modifier '/' in /var/www/wordpress/wp-content/plugins/widget-options/includes/extras.php on line 599;`